### PR TITLE
Change tag to playframework

### DIFF
--- a/activator.properties
+++ b/activator.properties
@@ -1,4 +1,4 @@
 name=play-slick-advanced
 title=Play Slick with Typesafe IDs
 description=Slick (the Scala Language-Integrated Connection Kit) is a framework for type safe, composable data access in Scala. This template combines Play Framework with Slick and adds tools to use type-safe IDs for your classes so you can no longer join on bad id field or mess up order of fields in mappings. It also provides way to create service with methods (like querying all, querying by id, saving or deleting), for all classes with such IDs in just 4 lines of code.
-tags=Advanced,play,scala,slick
+tags=Advanced,playframework,scala,slick


### PR DESCRIPTION
We want to use the Activator tag `playframework` for all Play related projects.
